### PR TITLE
Add unified search action for ChatGPT compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Bu proje, Borsa İstanbul (BIST) verilerine, Türk yatırım fonları verilerine
 🎯 **Temel Özellikler**
 
 * Borsa İstanbul (BIST), Türk yatırım fonları, global kripto para verileri ve döviz/emtia verilerine programatik erişim için kapsamlı bir MCP arayüzü.
+* Birleşik **`search`** MCP aracı ile şirket, endeks ve fon aramalarını tek bir çağrıda birleştirir.
 * **43 Araç** ile tam finansal analiz desteği:
     * **Şirket Arama:** 758 BIST şirketi arasında ticker kodu ve şirket adına göre arama (çoklu ticker desteği ile).
     * **Finansal Veriler:** Bilanço, kar-zarar, nakit akışı tabloları ve geçmiş OHLCV verileri.
@@ -45,6 +46,18 @@ Bu proje, Borsa İstanbul (BIST) verilerine, Türk yatırım fonları verilerine
 * **Hızlı İşleme:** Kısa araç açıklamaları ve LLM-dostu dokümantasyon ile optimize edilmiş performans.
 * Claude Desktop uygulaması ile kolay entegrasyon.
 * Borsa MCP, [5ire](https://5ire.app) gibi Claude Desktop haricindeki MCP istemcilerini de destekler.
+
+## 🔎 MCP HTTP Discovery & Search Action
+
+FastAPI katmanı, MCP istemcilerinin HTTP üzerinden otomatik keşif yapabilmesi ve birleşik aramayı tetikleyebilmesi için aşağıdaki uç noktaları sunar:
+
+| Endpoint | Açıklama |
+| --- | --- |
+| `/.well-known/mcp` ve `/.well-known/mcp.json` | Standart MCP discovery dökümü (JSON).
+| `/mcp/discovery` | FastMCP discovery helper'ı ile aynı içeriği döner.
+| `/mcp/actions/search` | HTTP tabanlı MCP `search` action tetikleyicisi. | 
+
+`/mcp/actions/search` endpoint'i, `query`, `category` (`auto`, `company`, `index`, `fund`) ve `limit` alanlarını kabul eder. Yanıt, MCP protokolünün beklediği `items` listesini döndürür ve şirket/endeks/fon sonuçlarının tümünü tek bir düz listede toplar. Bu sayede ChatGPT gibi istemciler ek yapılandırma gerektirmeden "search action" gerekliliklerini karşılayabilir.
 
 ## 📑 **İçindekiler**
 
@@ -157,6 +170,7 @@ Bu bölüm, Borsa MCP aracını 5ire gibi Claude Desktop dışındaki MCP istemc
 Bu FastMCP sunucusu LLM modelleri için aşağıdaki araçları sunar:
 
 ### Temel Şirket & Finansal Veriler
+* **`search`**: Şirket, endeks ve fon aramalarını otomatik olarak kategorize eden birleşik arama aracı.
 * **`find_ticker_code`**: Güncel BIST şirketleri arasında ticker kodu arama.
 * **`get_sirket_profili`**: Detaylı şirket profili.
 * **`get_bilanco`**: Bilanço verileri (yıllık/çeyreklik).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ FastAPI katmanı, MCP istemcilerinin HTTP üzerinden otomatik keşif yapabilmesi
 | `/mcp/discovery` | FastMCP discovery helper'ı ile aynı içeriği döner.
 | `/mcp/actions/search` | HTTP tabanlı MCP `search` action tetikleyicisi. | 
 
-`/mcp/actions/search` endpoint'i, `query`, `category` (`auto`, `company`, `index`, `fund`) ve `limit` alanlarını kabul eder. Yanıt, MCP protokolünün beklediği `items` listesini döndürür ve şirket/endeks/fon sonuçlarının tümünü tek bir düz listede toplar. Bu sayede ChatGPT gibi istemciler ek yapılandırma gerektirmeden "search action" gerekliliklerini karşılayabilir.
+`/mcp/actions/search` endpoint'i, `query`, `category` (`auto`, `company`, `index`, `fund`), isteğe bağlı `fund_category` (ör. `equity`, `precious_metals`, `money_market`) ve `limit` alanlarını kabul eder. Yanıt, MCP protokolünün beklediği `items` listesini döndürür ve şirket/endeks/fon sonuçlarının tümünü tek bir düz listede toplar. Bu sayede ChatGPT gibi istemciler ek yapılandırma gerektirmeden "search action" gerekliliklerini karşılayabilir.
+
+FastMCP içindeki birleşik `search` aracı aynı filtreyi `fon_kategorisi` parametresi üzerinden destekler. Varsayılan değer `all` olup, sadece belirli bir kategoriye odaklanmak istediğinizde bu parametreyi (`equity`, `mixed`, `participation` vb.) değiştirebilirsiniz.
 
 ## 📑 **İçindekiler**
 

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -101,7 +101,7 @@ def _build_search_items(result: GenelAramaSonucu) -> List[Dict[str, Any]]:
                         "manager": fund.yonetici,
                         "risk": fund.risk_degeri,
                         # 'veri_kaynak' may be missing if the upstream payload omits the field.
-                        "source": fund.veri_kaynak if hasattr(fund, "veri_kaynak") and fund.veri_kaynak else "tefas",
+                        "source": getattr(fund, "veri_kaynak", "tefas") or "tefas",
                     },
                 }
             )

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -270,9 +270,9 @@ async def mcp_search_action(payload: SearchActionRequest):
         )
     except ToolError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:  # pragma: no cover - defensive safeguard
-        logger.exception("Search action failed for query '%s'", payload.query)
-        raise HTTPException(status_code=500, detail="Search action failed.") from exc
+    except (ValueError, TypeError) as exc:
+        logger.exception("Invalid search parameters for query '%s'", payload.query)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     items = _build_search_items(result)
 

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -134,7 +134,7 @@ async def well_known_mcp():
             "name": "Borsa MCP Server",
             "version": "0.1.0",
             "endpoint": f"{BASE_URL}/mcp",
-            "capabilities": ["tools", "resources"],
+            "capabilities": ["tools", "resources", "actions"],
             "tools_count": len(mcp_server._tool_manager._tools) if hasattr(mcp_server, '_tool_manager') else 40
         }
     }
@@ -153,7 +153,13 @@ async def mcp_discovery():
         "capabilities": {
             "tools": True,
             "resources": True,
-            "prompts": False
+            "prompts": False,
+            "actions": {
+                "search": {
+                    "tool": "search",
+                    "description": "Unified search across BIST companies, indices, and TEFAS funds."
+                }
+            }
         },
         "tools_count": len(mcp_server._tool_manager._tools) if hasattr(mcp_server, '_tool_manager') else 40,
         "contact": {

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -95,9 +95,7 @@ def _build_search_items(result: GenelAramaSonucu) -> List[Dict[str, Any]]:
                         "fund_type": fund.fon_turu,
                         "manager": fund.yonetici,
                         "risk": fund.risk_degeri,
-                        "source": fund.veri_kaynak
-                        if hasattr(fund, "veri_kaynak") and fund.veri_kaynak is not None
-                        else "tefas",
+                        "source": getattr(fund, "veri_kaynak", None) or "tefas",
                     },
                 }
             )

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -236,9 +236,10 @@ async def genel_arama(
 
     if arama_kategorisi in ("auto", "fund"):
         try:
-            fund_result = await borsa_client.search_funds(
+            fund_result = await search_funds(
                 arama_terimi,
                 limit=sonuc_limiti,
+                fund_category="all",  # Unified discovery always surfaces funds across categories.
             )
             if fund_result.error_message:
                 fon_sonuclari = fund_result

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -2,6 +2,7 @@
 Main FastMCP server file for the Borsa Istanbul (BIST) data service.
 This version uses KAP for company search and yfinance for all financial data.
 """
+import inspect
 import logging
 import os
 import ssl
@@ -248,10 +249,18 @@ async def genel_arama(
 
     if kategori in ("auto", "fund"):
         try:
+            fund_kwargs: dict[str, Any] = {"limit": sonuc_limiti}
+            try:
+                signature = inspect.signature(borsa_client.search_funds)
+            except (TypeError, ValueError):
+                signature = None
+
+            if signature and "use_takasbank" in signature.parameters:
+                fund_kwargs["use_takasbank"] = takasbank_verisini_kullan
+
             fund_result = await borsa_client.search_funds(
                 arama_terimi,
-                limit=sonuc_limiti,
-                use_takasbank=takasbank_verisini_kullan,
+                **fund_kwargs,
             )
             if fund_result.error_message:
                 fon_sonuclari = fund_result

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -144,6 +144,9 @@ async def genel_arama(
 ) -> GenelAramaSonucu:
     """General search helper used by ChatGPT to discover relevant tickers or funds."""
 
+    if not arama_kategorisi:
+        arama_kategorisi = "auto"
+
     logger.info(
         "Tool 'search' called with query=%r, category=%s, limit=%s",
         arama_terimi,
@@ -155,14 +158,13 @@ async def genel_arama(
         raise ToolError("You must enter at least 2 characters to search.")
 
     arama_terimi = arama_terimi.strip()
-    kategori = arama_kategorisi or "auto"
 
     sirket_sonuclari = None
     endeks_sonuclari = None
     fon_sonuclari = None
     ozet_bolumleri: list[str] = []
 
-    if kategori in ("auto", "company"):
+    if arama_kategorisi in ("auto", "company"):
         try:
             company_result = await borsa_client.search_companies_from_kap(arama_terimi)
             toplam = len(company_result.sonuclar)
@@ -198,7 +200,7 @@ async def genel_arama(
             )
             ozet_bolumleri.append("Şirket araması başarısız oldu.")
 
-    if kategori in ("auto", "index"):
+    if arama_kategorisi in ("auto", "index"):
         try:
             index_result = await borsa_client.search_indices_from_kap(arama_terimi)
             toplam = len(index_result.sonuclar)
@@ -235,7 +237,7 @@ async def genel_arama(
             )
             ozet_bolumleri.append("Endeks araması başarısız oldu.")
 
-    if kategori in ("auto", "fund"):
+    if arama_kategorisi in ("auto", "fund"):
         try:
             fund_result = await borsa_client.search_funds(
                 arama_terimi,
@@ -269,7 +271,7 @@ async def genel_arama(
 
     return GenelAramaSonucu(
         arama_terimi=arama_terimi,
-        arama_kategorisi=kategori,
+        arama_kategorisi=arama_kategorisi,
         sirket_sonuclari=sirket_sonuclari,
         endeks_sonuclari=endeks_sonuclari,
         fon_sonuclari=fon_sonuclari,

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -166,6 +166,22 @@ async def genel_arama(
 
     arama_terimi = arama_terimi.strip()
 
+    allowed_categories = {"auto", "company", "index", "fund"}
+    if arama_kategorisi not in allowed_categories:
+        logger.warning(
+            "Unsupported search category '%s' requested for unified search.",
+            arama_kategorisi,
+        )
+        return GenelAramaSonucu(
+            arama_terimi=arama_terimi,
+            arama_kategorisi=arama_kategorisi,
+            sirket_sonuclari=None,
+            endeks_sonuclari=None,
+            fon_sonuclari=None,
+            fon_kategorisi=None,
+            ozet="Arama yapılacak kategori bulunamadı.",
+        )
+
     sirket_sonuclari = None
     endeks_sonuclari = None
     fon_sonuclari = None
@@ -280,10 +296,7 @@ async def genel_arama(
             )
             ozet_bolumleri.append("Fon araması başarısız oldu.")
 
-    if not ozet_bolumleri:
-        ozet = "Arama yapılacak kategori bulunamadı."
-    else:
-        ozet = " ".join(ozet_bolumleri)
+    ozet = " ".join(ozet_bolumleri)
 
     return GenelAramaSonucu(
         arama_terimi=arama_terimi,

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -144,9 +144,6 @@ async def genel_arama(
 ) -> GenelAramaSonucu:
     """General search helper used by ChatGPT to discover relevant tickers or funds."""
 
-    if not arama_kategorisi:
-        arama_kategorisi = "auto"
-
     logger.info(
         "Tool 'search' called with query=%r, category=%s, limit=%s",
         arama_terimi,

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -2,7 +2,6 @@
 Main FastMCP server file for the Borsa Istanbul (BIST) data service.
 This version uses KAP for company search and yfinance for all financial data.
 """
-import inspect
 import logging
 import os
 import ssl
@@ -142,25 +141,14 @@ async def genel_arama(
             default=10,
         ),
     ] = 10,
-    takasbank_verisini_kullan: Annotated[
-        bool,
-        Field(
-            description=(
-                "Fund search data source. True uses Takasbank cached dataset (faster, defaults). "
-                "False switches to live TEFAS API advanced search."
-            ),
-            default=True,
-        ),
-    ] = True,
 ) -> GenelAramaSonucu:
     """General search helper used by ChatGPT to discover relevant tickers or funds."""
 
     logger.info(
-        "Tool 'search' called with query=%r, category=%s, limit=%s, takasbank=%s",
+        "Tool 'search' called with query=%r, category=%s, limit=%s",
         arama_terimi,
         arama_kategorisi,
         sonuc_limiti,
-        takasbank_verisini_kullan,
     )
 
     if not arama_terimi or len(arama_terimi.strip()) < 2:
@@ -249,18 +237,9 @@ async def genel_arama(
 
     if kategori in ("auto", "fund"):
         try:
-            fund_kwargs: dict[str, Any] = {"limit": sonuc_limiti}
-            try:
-                signature = inspect.signature(borsa_client.search_funds)
-            except (TypeError, ValueError):
-                signature = None
-
-            if signature and "use_takasbank" in signature.parameters:
-                fund_kwargs["use_takasbank"] = takasbank_verisini_kullan
-
             fund_result = await borsa_client.search_funds(
                 arama_terimi,
-                **fund_kwargs,
+                limit=sonuc_limiti,
             )
             if fund_result.error_message:
                 fon_sonuclari = fund_result

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -109,6 +109,9 @@ from .regulation_models import (
     FonMevzuatSonucu
 )
 
+# General search models
+from .search_models import GenelAramaSonucu
+
 # Export all models for backward compatibility
 __all__ = [
     # Base enums
@@ -169,7 +172,10 @@ __all__ = [
     
     # Economic calendar models
     "EkonomikOlayDetayi", "EkonomikOlay", "EkonomikTakvimSonucu",
-    
+
     # Fund regulation models
-    "FonMevzuatSonucu"
+    "FonMevzuatSonucu",
+
+    # General search models
+    "GenelAramaSonucu",
 ]

--- a/models/search_models.py
+++ b/models/search_models.py
@@ -1,0 +1,33 @@
+"""General search models combining multiple provider search results."""
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .kap_models import EndeksKoduAramaSonucu, SirketAramaSonucu
+from .tefas_models import FonAramaSonucu
+
+
+class GenelAramaSonucu(BaseModel):
+    """Aggregated search result combining company, index, and fund matches."""
+
+    arama_terimi: str = Field(description="The original search query that was used.")
+    arama_kategorisi: Literal["auto", "company", "index", "fund"] = Field(
+        description="Specifies which data domain was searched. 'auto' searches all domains."
+    )
+    sirket_sonuclari: Optional[SirketAramaSonucu] = Field(
+        None,
+        description="Matching BIST company results when company search is requested.",
+    )
+    endeks_sonuclari: Optional[EndeksKoduAramaSonucu] = Field(
+        None, description="Matching BIST index results when index search is requested."
+    )
+    fon_sonuclari: Optional[FonAramaSonucu] = Field(
+        None, description="Matching TEFAS fund results when fund search is requested."
+    )
+    ozet: Optional[str] = Field(
+        None,
+        description=(
+            "Human readable summary describing how many results were returned for each domain."
+        ),
+    )
+

--- a/models/search_models.py
+++ b/models/search_models.py
@@ -14,6 +14,10 @@ class GenelAramaSonucu(BaseModel):
     arama_kategorisi: Literal["auto", "company", "index", "fund"] = Field(
         description="Specifies which data domain was searched. 'auto' searches all domains."
     )
+    fon_kategorisi: Optional[str] = Field(
+        None,
+        description="Fund category filter forwarded to TEFAS search when provided.",
+    )
     sirket_sonuclari: Optional[SirketAramaSonucu] = Field(
         None,
         description="Matching BIST company results when company search is requested.",


### PR DESCRIPTION
## Summary
- add a new `search` tool that aggregates company, index, and fund lookups for ChatGPT
- introduce a combined search response model to return grouped results
- advertise the search capability through the HTTP discovery metadata

## Testing
- python -m compileall borsa_mcp_server.py models asgi_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d48ae70e30832aa3ceef79432cdc08