### PR TITLE
Deduplicate unified search result handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Bu proje, Borsa İstanbul (BIST) verilerine, Türk yatırım fonları verilerine
 🎯 **Temel Özellikler**
 
 * Borsa İstanbul (BIST), Türk yatırım fonları, global kripto para verileri ve döviz/emtia verilerine programatik erişim için kapsamlı bir MCP arayüzü.
+* Birleşik **`search`** MCP aracı ile şirket, endeks ve fon aramalarını tek bir çağrıda birleştirir.
 * **43 Araç** ile tam finansal analiz desteği:
     * **Şirket Arama:** 758 BIST şirketi arasında ticker kodu ve şirket adına göre arama (çoklu ticker desteği ile).
     * **Finansal Veriler:** Bilanço, kar-zarar, nakit akışı tabloları ve geçmiş OHLCV verileri.
@@ -45,6 +46,20 @@ Bu proje, Borsa İstanbul (BIST) verilerine, Türk yatırım fonları verilerine
 * **Hızlı İşleme:** Kısa araç açıklamaları ve LLM-dostu dokümantasyon ile optimize edilmiş performans.
 * Claude Desktop uygulaması ile kolay entegrasyon.
 * Borsa MCP, [5ire](https://5ire.app) gibi Claude Desktop haricindeki MCP istemcilerini de destekler.
+
+## 🔎 MCP HTTP Discovery & Search Action
+
+FastAPI katmanı, MCP istemcilerinin HTTP üzerinden otomatik keşif yapabilmesi ve birleşik aramayı tetikleyebilmesi için aşağıdaki uç noktaları sunar:
+
+| Endpoint | Açıklama |
+| --- | --- |
+| `/.well-known/mcp` ve `/.well-known/mcp.json` | Standart MCP discovery dökümü (JSON).
+| `/mcp/discovery` | FastMCP discovery helper'ı ile aynı içeriği döner.
+| `/mcp/actions/search` | HTTP tabanlı MCP `search` action tetikleyicisi. | 
+
+`/mcp/actions/search` endpoint'i, `query`, `category` (`auto`, `company`, `index`, `fund`), isteğe bağlı `fund_category` (ör. `equity`, `precious_metals`, `money_market`) ve `limit` alanlarını kabul eder. Yanıt, MCP protokolünün beklediği `items` listesini döndürür ve şirket/endeks/fon sonuçlarının tümünü tek bir düz listede toplar. Bu sayede ChatGPT gibi istemciler ek yapılandırma gerektirmeden "search action" gerekliliklerini karşılayabilir.
+
+FastMCP içindeki birleşik `search` aracı aynı filtreyi `fon_kategorisi` parametresi üzerinden destekler. Varsayılan değer `all` olup, sadece belirli bir kategoriye odaklanmak istediğinizde bu parametreyi (`equity`, `mixed`, `participation` vb.) değiştirebilirsiniz.
 
 ## 📑 **İçindekiler**
 
@@ -157,6 +172,7 @@ Bu bölüm, Borsa MCP aracını 5ire gibi Claude Desktop dışındaki MCP istemc
 Bu FastMCP sunucusu LLM modelleri için aşağıdaki araçları sunar:
 
 ### Temel Şirket & Finansal Veriler
+* **`search`**: Şirket, endeks ve fon aramalarını otomatik olarak kategorize eden birleşik arama aracı.
 * **`find_ticker_code`**: Güncel BIST şirketleri arasında ticker kodu arama.
 * **`get_sirket_profili`**: Detaylı şirket profili.
 * **`get_bilanco`**: Bilanço verileri (yıllık/çeyreklik).

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -100,8 +100,7 @@ def _build_search_items(result: GenelAramaSonucu) -> List[Dict[str, Any]]:
                         "fund_type": fund.fon_turu,
                         "manager": fund.yonetici,
                         "risk": fund.risk_degeri,
-                        # 'veri_kaynak' may be missing if the upstream payload omits the field.
-                        "source": getattr(fund, "veri_kaynak", "tefas") or "tefas",
+                        "source": fund.veri_kaynak or "tefas",
                     },
                 }
             )

--- a/asgi_app.py
+++ b/asgi_app.py
@@ -49,7 +49,21 @@ class SearchActionRequest(BaseModel):
 
 
 def _build_search_items(result: GenelAramaSonucu) -> List[Dict[str, Any]]:
-    """Flatten grouped search results into MCP search action items."""
+    """
+    Combines search results from companies, indices, and funds into a single flat list.
+
+    Each item in the returned list follows the MCP search action format:
+        {
+            "id": str,         # Unique identifier prefixed by type (e.g., "company:XXX")
+            "title": str,      # Display name with code
+            "type": str,       # One of "company", "index", or "fund"
+            "url": str,        # Link to details page
+            "summary": str,    # Short description or type
+            "metadata": dict,  # Additional metadata specific to the item type
+        }
+
+    The function flattens and merges results from companies, indices, and funds into this unified format.
+    """
 
     items: List[Dict[str, Any]] = []
 
@@ -210,7 +224,11 @@ async def root():
 
 # Standardized MCP discovery payload builder so all endpoints share the same schema
 def _build_discovery_payload() -> Dict[str, Any]:
-    """Create an MCP discovery payload that follows the HTTP transport specification."""
+    """
+    Create an MCP discovery payload that follows the MCP HTTP transport specification v1.0.
+
+    This format follows MCP HTTP transport specification version 1.0.
+    """
 
     base_endpoint = f"{BASE_URL.rstrip('/')}/mcp"
     search_schema = SearchActionRequest.model_json_schema()

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -129,12 +129,6 @@ def _trim_list_result(
 ) -> tuple[SearchResultModel, str]:
     """Trim list-based KAP search results and create a summary snippet."""
 
-    if not isinstance(result, SupportsListResult):
-        raise TypeError(
-            f"Expected search result model implementing SupportsListResult protocol, "
-            f"but received instance of {type(result).__name__}."
-        )
-
     items = result.sonuclar
     total = len(items)
 

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -105,7 +105,12 @@ def _trim_list_result(
 ) -> tuple[SearchResultModel, str]:
     """Trim list-based KAP search results and create a summary snippet."""
 
-    items = getattr(result, "sonuclar", [])
+    if not hasattr(result, "sonuclar"):
+        raise TypeError(
+            f"{type(result).__name__} does not expose required 'sonuclar' attribute"
+        )
+
+    items = result.sonuclar
     total = len(items)
 
     if total > 0:

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -129,13 +129,9 @@ def _trim_list_result(
 ) -> tuple[SearchResultModel, str]:
     """Trim list-based KAP search results and create a summary snippet."""
 
-    if not (
-        hasattr(result, "sonuclar")
-        and hasattr(result, "model_copy")
-        and callable(getattr(result, "model_copy", None))
-    ):
+    if not isinstance(result, SupportsListResult):
         raise TypeError(
-            "Expected search result model with required attributes ('sonuclar', 'model_copy'), "
+            "Expected search result model implementing SupportsListResult with 'sonuclar' support, "
             f"but received instance of {type(result).__name__}."
         )
 

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -131,7 +131,7 @@ def _trim_list_result(
 
     if not isinstance(result, SupportsListResult):
         raise TypeError(
-            "Expected search result model implementing SupportsListResult with 'sonuclar' support, "
+            f"Expected search result model implementing SupportsListResult protocol, "
             f"but received instance of {type(result).__name__}."
         )
 

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -129,9 +129,13 @@ def _trim_list_result(
 ) -> tuple[SearchResultModel, str]:
     """Trim list-based KAP search results and create a summary snippet."""
 
-    if not isinstance(result, SupportsListResult):
+    if not (
+        hasattr(result, "sonuclar")
+        and hasattr(result, "model_copy")
+        and callable(getattr(result, "model_copy", None))
+    ):
         raise TypeError(
-            "Expected search result model implementing SupportsListResult protocol, "
+            "Expected search result model with required attributes ('sonuclar', 'model_copy'), "
             f"but received instance of {type(result).__name__}."
         )
 

--- a/borsa_mcp_server.py
+++ b/borsa_mcp_server.py
@@ -107,7 +107,8 @@ def _trim_list_result(
 
     if not hasattr(result, "sonuclar"):
         raise TypeError(
-            f"{type(result).__name__} does not expose required 'sonuclar' attribute"
+            f"Expected search result model with 'sonuclar' attribute, "
+            f"but {type(result).__name__} does not have this attribute."
         )
 
     items = result.sonuclar
@@ -115,7 +116,7 @@ def _trim_list_result(
 
     if total > 0:
         if total > limit:
-            trimmed_items = list(items[:limit])
+            trimmed_items = items[:limit]
             trimmed_result = result.model_copy(
                 update={
                     "sonuclar": trimmed_items,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -109,6 +109,9 @@ from .regulation_models import (
     FonMevzuatSonucu
 )
 
+# General search models
+from .search_models import GenelAramaSonucu
+
 # Export all models for backward compatibility
 __all__ = [
     # Base enums
@@ -169,7 +172,10 @@ __all__ = [
     
     # Economic calendar models
     "EkonomikOlayDetayi", "EkonomikOlay", "EkonomikTakvimSonucu",
-    
+
     # Fund regulation models
-    "FonMevzuatSonucu"
+    "FonMevzuatSonucu",
+
+    # General search models
+    "GenelAramaSonucu",
 ]

--- a/models/search_models.py
+++ b/models/search_models.py
@@ -1,0 +1,37 @@
+"""General search models combining multiple provider search results."""
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .kap_models import EndeksKoduAramaSonucu, SirketAramaSonucu
+from .tefas_models import FonAramaSonucu
+
+
+class GenelAramaSonucu(BaseModel):
+    """Aggregated search result combining company, index, and fund matches."""
+
+    arama_terimi: str = Field(description="The original search query that was used.")
+    arama_kategorisi: Literal["auto", "company", "index", "fund"] = Field(
+        description="Specifies which data domain was searched. 'auto' searches all domains."
+    )
+    fon_kategorisi: Optional[str] = Field(
+        None,
+        description="Fund category filter forwarded to TEFAS search when provided.",
+    )
+    sirket_sonuclari: Optional[SirketAramaSonucu] = Field(
+        None,
+        description="Matching BIST company results when company search is requested.",
+    )
+    endeks_sonuclari: Optional[EndeksKoduAramaSonucu] = Field(
+        None, description="Matching BIST index results when index search is requested."
+    )
+    fon_sonuclari: Optional[FonAramaSonucu] = Field(
+        None, description="Matching TEFAS fund results when fund search is requested."
+    )
+    ozet: Optional[str] = Field(
+        None,
+        description=(
+            "Human readable summary describing how many results were returned for each domain."
+        ),
+    )
+

--- a/models/tefas_models.py
+++ b/models/tefas_models.py
@@ -44,7 +44,9 @@ class FonAramaSonucu(BaseModel):
     toplam_fon_sayisi: Optional[int] = Field(None, description="Total funds available in database.")
     kategori_listesi: Optional[List[str]] = Field(None, description="Available fund categories.")
     siralam_kriteri: Optional[str] = Field(None, description="Sort criteria applied.")
-    veri_kaynak: Optional[str] = Field(None, description="Data source: 'takasbank' or 'tefas'.")
+    veri_kaynak: Optional[str] = Field(
+        "tefas", description="Data source: 'takasbank' or 'tefas'."
+    )
     
     error_message: Optional[str] = Field(None, description="Error message if search failed.")
 


### PR DESCRIPTION
## Summary
- introduce a reusable helper to trim list-based KAP search results and generate the related summary text
- rely on the Literal-enforced category validation instead of maintaining a duplicate allowed set in the unified search tool

## Testing
- python -m compileall borsa_mcp_server.py models asgi_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d48ae70e30832aa3ceef79432cdc08